### PR TITLE
set secure cookie

### DIFF
--- a/routes/consent.js
+++ b/routes/consent.js
@@ -5,7 +5,7 @@ var hydra = require('../services/hydra')
 
 // Sets up csrf protection
 var csrf = require('csurf');
-var csrfProtection = csrf({ cookie: true });
+var csrfProtection = csrf({ cookie: true, secure: true });
 
 router.get('/', csrfProtection, function (req, res, next) {
   // Parses the URL query

--- a/routes/login.js
+++ b/routes/login.js
@@ -5,7 +5,7 @@ var hydra = require('../services/hydra')
 
 // Sets up csrf protection
 var csrf = require('csurf');
-var csrfProtection = csrf({ cookie: true });
+var csrfProtection = csrf({ cookie: true, secure: true});
 
 router.get('/', csrfProtection, function (req, res, next) {
   // Parses the URL query

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -5,7 +5,7 @@ var hydra = require('../services/hydra')
 
 // Sets up csrf protection
 var csrf = require('csurf');
-var csrfProtection = csrf({ cookie: true });
+var csrfProtection = csrf({ cookie: true, secure: true });
 
 router.get('/', csrfProtection, function (req, res, next) {
   // Parses the URL query


### PR DESCRIPTION
New versions of Chrome warn about an io cookie set with 'SameSite=None' but without 'Secure'.

This provokes undesired blocking of requests, as Chrome now only delivers cookies marked SameSite=None if they are also marked Secure. 

We set the cookie secure to true.